### PR TITLE
fix VPC name check

### DIFF
--- a/templates/aws-refarch-drupal-02-securitygroups.yaml
+++ b/templates/aws-refarch-drupal-02-securitygroups.yaml
@@ -24,7 +24,7 @@ Parameters:
     Type: String
     Default: 0.0.0.0/0
   Vpc:
-    AllowedPattern: ^(vpc-)([a-z0-9]{8})$
+    AllowedPattern: ^(vpc-)([a-z0-9]{8}|[a-z0-9]{17})$
     Description: The Vpc Id of an existing Vpc.
     Type: AWS::EC2::VPC::Id
 


### PR DESCRIPTION
Recently, VPC ID has two variation: vpc-xxxxxxxx and vpc-xxxxxxxxxxxxxxxxx .
Because of the change, creating stack was failed by VPC ID checking on SecurityGroup stack.
I fixed regex for the checking.
