### PR TITLE
Update aws-refarch-drupal-02-securitygroups.yaml

### DIFF
--- a/templates/aws-refarch-drupal-02-securitygroups.yaml
+++ b/templates/aws-refarch-drupal-02-securitygroups.yaml
@@ -24,7 +24,7 @@ Parameters:
     Type: String
     Default: 0.0.0.0/0
   Vpc:
-    AllowedPattern: ^(vpc-)([a-z0-9]{8})$
+    AllowedPattern: ^(vpc-)([a-z0-9]{17})$
     Description: The Vpc Id of an existing Vpc.
     Type: AWS::EC2::VPC::Id
 


### PR DESCRIPTION
support longer vpc id format
https://aws.amazon.com/blogs/compute/longer-resource-ids-in-2018-for-amazon-ec2-amazon-ebs-and-amazon-vpc/